### PR TITLE
Give server more time for data fetching

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -17,7 +17,8 @@ var PlayersTable = React.createClass({
       var nextRefresh = moment().add(data.secondsLeft, 'seconds');
       var cacheLifetime = data.cacheLifetime;
       var updateProgressBar = setInterval(function () {
-        var secondsLeft = nextRefresh.diff(moment(), 'seconds');
+        // Give server 3 more seconds to process the request
+        var secondsLeft = nextRefresh.diff(moment(), 'seconds') + 3;
         if (secondsLeft == 0) {
           clearInterval(updateProgressBar);
           self.loadData();

--- a/static/js/site.jsx
+++ b/static/js/site.jsx
@@ -17,7 +17,8 @@ var PlayersTable = React.createClass({
       var nextRefresh = moment().add(data.secondsLeft, 'seconds');
       var cacheLifetime = data.cacheLifetime;
       var updateProgressBar = setInterval(function () {
-          var secondsLeft = nextRefresh.diff(moment(), 'seconds');
+          // Give server 3 more seconds to process the request
+          var secondsLeft = nextRefresh.diff(moment(), 'seconds') + 3;
           if (secondsLeft == 0) {
             clearInterval(updateProgressBar);
             self.loadData();


### PR DESCRIPTION
Currently server returns the timeout for when it will start fetching new data. But data fetch takes some time (around 1 second). Most often JS manages to make a request before the data fetch takes place.

Now it makes 2 subsequent request in a very short interval of time
![image](https://cloud.githubusercontent.com/assets/171178/18289569/cd772210-7477-11e6-8e51-07f1820d70ba.png)

Adding a delay changes the behavior to just one subsequent request.
![image](https://cloud.githubusercontent.com/assets/171178/18289483/7abcae28-7477-11e6-92df-727748694d10.png)
